### PR TITLE
Support for Statements and Extended Attributes

### DIFF
--- a/src/DNSimple.Api/DNSimple.Api.csproj
+++ b/src/DNSimple.Api/DNSimple.Api.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="Contacts.cs" />
     <Compile Include="NameServers.cs" />
+    <Compile Include="Statements.cs" />
     <Compile Include="Users.cs" />
     <Compile Include="SSL.cs" />
     <Compile Include="Sharing.cs" />

--- a/src/DNSimple.Api/ExtendedAttributes.cs
+++ b/src/DNSimple.Api/ExtendedAttributes.cs
@@ -7,6 +7,20 @@ namespace DNSimple
 {
 	public partial class DNSimpleRestClient
 	{
-		
+		/// <summary>
+		/// Retrieve the extended attributes required for a specific top level domain.
+		/// Makes a GET request to the Extended Attributes resource.
+		/// </summary>
+		/// <param name="name">The tld to retrieve the extended attributes for</param>
+		public dynamic GetExtendedAttributes(string tld) {
+			Require.Argument("tld", tld);
+
+			var request = new RestRequest {
+				Resource = "extended_attributes/{tld}"
+			};
+			request.AddUrlSegment("tld", tld);
+
+			return Execute<dynamic>(request);
+		}
 	}
 }

--- a/src/DNSimple.Api/Statements.cs
+++ b/src/DNSimple.Api/Statements.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using RestSharp;
+using RestSharp.Validation;
+
+namespace DNSimple
+{
+	public partial class DNSimpleRestClient
+	{
+		/// <summary>
+		/// Retrieve the statements for this account.
+		/// Makes a GET request to the Statements resource.
+		/// </summary>
+		public dynamic GetStatements() {
+			var request = new RestRequest {
+				Resource = "statements"
+			};
+
+			return Execute<dynamic>(request);
+		}
+	}
+}


### PR DESCRIPTION
Some more low hanging fruit ticked off...

It should be all tabs and not spaces now - I didn't notice that I was using spaces after switching to VS 11.

I'm not sure why adding a file (Statements.cs) results in the entire csproj file changing but that's all that change is.
