### PR TITLE
Updated default BaseUrl and ApiVersion to their new values as the API cu...

### DIFF
--- a/src/DNSimple.Api/Core.cs
+++ b/src/DNSimple.Api/Core.cs
@@ -14,10 +14,8 @@ namespace DNSimple
 	    private DNSimpleRestClient()
 	    {
 	        Version version = new AssemblyName(Assembly.GetExecutingAssembly().FullName).Version;
-            // Typically this would be something like "v1" or "2012-01-01", so we'll just stub it out empty 
-            // for now to allow for future support
-            ApiVersion = "";
-            BaseUrl = "https://dnsimple.com/";
+            ApiVersion = "v1";
+            BaseUrl = "https://api.dnsimple.com/";
 
             _client = new RestClient
             {
@@ -27,11 +25,11 @@ namespace DNSimple
         }
 
 	    /// <summary>
-		/// DNSimple API version to use when making requests
+		/// DNSimple API version to use when making requests (defaults to v1)
 		/// </summary>
 		public string ApiVersion { get; set; }
 		/// <summary>
-		/// Base URL of API (defaults to https://dnsimple.com/)
+		/// Base URL of API (defaults to https://api.dnsimple.com/)
 		/// </summary>
 		public string BaseUrl { get; set; }
 


### PR DESCRIPTION
Updated default BaseUrl and ApiVersion to https://api.dnsimple.com and v1 respectively. The API address currently used is now deprecated and soon to be shut down. See http://blog.dnsimple.com/2014/01/versioned-api/ for details.
